### PR TITLE
Fixes GFF3 for annotations created with prokka

### DIFF
--- a/workflow/rules/download_sampled_data.smk
+++ b/workflow/rules/download_sampled_data.smk
@@ -208,7 +208,8 @@ rule prokka:
         "workflow_files/genomes_wo_annotation/{prokka_accession}.fna"
     output:
         proteomes="workflow_files/prokka/{prokka_accession}/{prokka_accession}.faa",
-        cds="workflow_files/prokka/{prokka_accession}/{prokka_accession}.ffn"
+        cds="workflow_files/prokka/{prokka_accession}/{prokka_accession}.ffn",
+        gff3="workflow_files/prokka/{prokka_accession}/{prokka_accession}.gff"
     params:
         prefix="{prokka_accession}",
         outdir="workflow_files/prokka/{prokka_accession}"

--- a/workflow/rules/gtdb_taxonomy_phylogeny.smk
+++ b/workflow/rules/gtdb_taxonomy_phylogeny.smk
@@ -84,7 +84,7 @@ rule download_gtdb_summary:
         awk -F'\\t'  '{{ print $1 }}' {input} | sed '1d' > accessions.tmp;
         head accessions.tmp;
         datasets summary genome accession --inputfile accessions.tmp \
-            --as-json-lines | \
+            --as-json-lines | sed 's/\\\\t//g' | \
         dataformat tsv genome > {output};
         rm accessions.tmp;
         """

--- a/workflow/scripts/link_files.py
+++ b/workflow/scripts/link_files.py
@@ -9,8 +9,8 @@ if not os.path.exists(out_dir):
     os.makedirs(out_dir)
 for f in snakemake.input:
     fname = os.path.split(f)[1]
-    src_abs_path = os.path.abspath(f)
+    src_rel_path = os.path.relpath(f, start = out_dir)
     target = os.path.join(out_dir,fname)
     target_abs_path = os.path.abspath(target)
-    os.symlink(src_abs_path, target_abs_path)
-    print(f"Link {src_abs_path} to {out_dir}")
+    os.symlink(src_rel_path, target_abs_path)
+    print(f"Link {src_rel_path} to {out_dir}")

--- a/workflow/scripts/merge_datasets.py
+++ b/workflow/scripts/merge_datasets.py
@@ -7,7 +7,7 @@ import pandas as pd
 # Open and merge the tables
 dfs = []
 for df_path in snakemake.input:
-    df = pd.read_csv(df_path, sep="\t")
+    df = pd.read_csv(df_path, sep="\t", lineterminator="\n")
     dfs.append(df)
 df = pd.concat(dfs)
 


### PR DESCRIPTION
Downloading GFF3 files currently fails if prokka is involved, which this fixes.